### PR TITLE
Update Makefile

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -36,7 +36,7 @@ define Package/node
   SUBMENU:=Node.js
   TITLE:=Node.js is a platform built on Chrome's JavaScript runtime
   URL:=http://nodejs.org/
-  DEPENDS:=+libstdcpp +libopenssl +zlib
+  DEPENDS:=+libstdcpp +libopenssl +zlib +libpthread +librt
 endef
 
 define Package/node/description


### PR DESCRIPTION
Node v4.5.0 is missing dependencies for libraries.

Testing target : MT7628. (The Node.js is working well. :+1: )