### PR TITLE
node8 : refreshing patches for HOST build with gcc v6 series

### DIFF
--- a/node/patches/v8.x/010-execvp-arg-list-too-long.patch
+++ b/node/patches/v8.x/010-execvp-arg-list-too-long.patch
@@ -1,0 +1,176 @@
+diff --git a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/make.py b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/make.py
+index 64b9dd267b..1ddd95b86b 100644
+--- a/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/make.py
++++ b/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/generator/make.py
+@@ -144,6 +144,30 @@ cmd_alink_thin = rm -f $@ && $(AR.$(TOOLSET)) crsT $@ $(filter %.o,$^)
+ quiet_cmd_link = LINK($(TOOLSET)) $@
+ cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ -Wl,--start-group $(LD_INPUTS) -Wl,--end-group $(LIBS)
+ 
++define xargs
++$(1) $(wordlist 1,1000,$(2))
++$(if $(word 1001,$(2)),$(call xargs,$(1),$(wordlist 1001,$(words $(2)),$(2))))
++endef
++
++define write-to-file
++@: >$(1)
++$(call xargs,@printf "%s\\n" >>$(1),$(2))
++endef
++
++OBJ_FILE_LIST := ar-file-list
++
++define create_archive
++        rm -f $(1) $(1).$(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crs $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
++define create_thin_archive
++        rm -f $(1) $(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crsT $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
+ # We support two kinds of shared objects (.so):
+ # 1) shared_library, which is just bundling together many dependent libraries
+ # into a link line.
+@@ -188,6 +212,30 @@ cmd_alink = rm -f $@ && $(AR.$(TOOLSET)) crs $@ $(filter %.o,$^)
+ quiet_cmd_alink_thin = AR($(TOOLSET)) $@
+ cmd_alink_thin = rm -f $@ && $(AR.$(TOOLSET)) crsT $@ $(filter %.o,$^)
+ 
++define xargs
++$(1) $(wordlist 1,1000,$(2))
++$(if $(word 1001,$(2)),$(call xargs,$(1),$(wordlist 1001,$(words $(2)),$(2))))
++endef
++
++define write-to-file
++@: >$(1)
++$(call xargs,@printf "%s\\n" >>$(1),$(2))
++endef
++
++OBJ_FILE_LIST := ar-file-list
++
++define create_archive
++        rm -f $(1) $(1).$(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crs $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
++define create_thin_archive
++        rm -f $(1) $(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crsT $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
+ # Due to circular dependencies between libraries :(, we wrap the
+ # special "figure out circular dependencies" flags around the entire
+ # input list during linking.
+@@ -1581,11 +1629,17 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
+             "Spaces in alink input filenames not supported (%s)"  % link_dep)
+       if (self.flavor not in ('mac', 'openbsd', 'netbsd', 'win') and not
+           self.is_standalone_static_library):
+-        self.WriteDoCmd([self.output_binary], link_deps, 'alink_thin',
+-                        part_of_all, postbuilds=postbuilds)
++        if self.flavor in ('linux', 'android'):
++          self.WriteMakeRule([self.output_binary], link_deps, actions = ['$(call create_thin_archive,$@,$^)'])
++        else:
++          self.WriteDoCmd([self.output_binary], link_deps, 'alink_thin',
++                          part_of_all, postbuilds=postbuilds)
+       else:
+-        self.WriteDoCmd([self.output_binary], link_deps, 'alink', part_of_all,
+-                        postbuilds=postbuilds)
++        if self.flavor in ('linux', 'android'):
++          self.WriteMakeRule([self.output_binary], link_deps, actions = ['$(call create_archive,$@,$^)'])
++        else:
++          self.WriteDoCmd([self.output_binary], link_deps, 'alink', part_of_all,
++                          postbuilds=postbuilds)
+     elif self.type == 'shared_library':
+       self.WriteLn('%s: LD_INPUTS := %s' % (
+             QuoteSpaces(self.output_binary),
+diff --git a/tools/gyp/pylib/gyp/generator/make.py b/tools/gyp/pylib/gyp/generator/make.py
+index f7f519b3e6..ce3ef71e4a 100644
+--- a/tools/gyp/pylib/gyp/generator/make.py
++++ b/tools/gyp/pylib/gyp/generator/make.py
+@@ -149,6 +149,30 @@ cmd_alink_thin = rm -f $@ && $(AR.$(TOOLSET)) crsT $@ $(filter %.o,$^)
+ quiet_cmd_link = LINK($(TOOLSET)) $@
+ cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o $@ -Wl,--start-group $(LD_INPUTS) $(LIBS) -Wl,--end-group
+ 
++define xargs
++$(1) $(wordlist 1,1000,$(2))
++$(if $(word 1001,$(2)),$(call xargs,$(1),$(wordlist 1001,$(words $(2)),$(2))))
++endef
++
++define write-to-file
++@: >$(1)
++$(call xargs,@printf "%s\\n" >>$(1),$(2))
++endef
++
++OBJ_FILE_LIST := ar-file-list
++
++define create_archive
++        rm -f $(1) $(1).$(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crs $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
++define create_thin_archive
++        rm -f $(1) $(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crsT $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
+ # We support two kinds of shared objects (.so):
+ # 1) shared_library, which is just bundling together many dependent libraries
+ # into a link line.
+@@ -193,6 +217,30 @@ cmd_alink = rm -f $@ && $(AR.$(TOOLSET)) crs $@ $(filter %.o,$^)
+ quiet_cmd_alink_thin = AR($(TOOLSET)) $@
+ cmd_alink_thin = rm -f $@ && $(AR.$(TOOLSET)) crsT $@ $(filter %.o,$^)
+ 
++define xargs
++$(1) $(wordlist 1,1000,$(2))
++$(if $(word 1001,$(2)),$(call xargs,$(1),$(wordlist 1001,$(words $(2)),$(2))))
++endef
++
++define write-to-file
++@: >$(1)
++$(call xargs,@printf "%s\\n" >>$(1),$(2))
++endef
++
++OBJ_FILE_LIST := ar-file-list
++
++define create_archive
++        rm -f $(1) $(1).$(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crs $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
++define create_thin_archive
++        rm -f $(1) $(OBJ_FILE_LIST); mkdir -p `dirname $(1)`
++        $(call write-to-file,$(1).$(OBJ_FILE_LIST),$(filter %.o,$(2)))
++        $(AR.$(TOOLSET)) crsT $(1) @$(1).$(OBJ_FILE_LIST)
++endef
++
+ # Due to circular dependencies between libraries :(, we wrap the
+ # special "figure out circular dependencies" flags around the entire
+ # input list during linking.
+@@ -1589,11 +1637,17 @@ $(obj).$(TOOLSET)/$(TARGET)/%%.o: $(obj)/%%%s FORCE_DO_CMD
+             "Spaces in alink input filenames not supported (%s)"  % link_dep)
+       if (self.flavor not in ('mac', 'openbsd', 'netbsd', 'win') and not
+           self.is_standalone_static_library):
+-        self.WriteDoCmd([self.output_binary], link_deps, 'alink_thin',
+-                        part_of_all, postbuilds=postbuilds)
++        if self.flavor in ('linux', 'android'):
++          self.WriteMakeRule([self.output_binary], link_deps, actions = ['$(call create_thin_archive,$@,$^)'])
++        else:
++          self.WriteDoCmd([self.output_binary], link_deps, 'alink_thin',
++                          part_of_all, postbuilds=postbuilds)
+       else:
+-        self.WriteDoCmd([self.output_binary], link_deps, 'alink', part_of_all,
+-                        postbuilds=postbuilds)
++        if self.flavor in ('linux', 'android'):
++          self.WriteMakeRule([self.output_binary], link_deps, actions = ['$(call create_archive,$@,$^)'])
++        else:
++          self.WriteDoCmd([self.output_binary], link_deps, 'alink', part_of_all,
++                          postbuilds=postbuilds)
+     elif self.type == 'shared_library':
+       self.WriteLn('%s: LD_INPUTS := %s' % (
+             QuoteSpaces(self.output_binary),

--- a/node/patches/v8.x/011-gyp-force-link-command-to-use-CXX.patch
+++ b/node/patches/v8.x/011-gyp-force-link-command-to-use-CXX.patch
@@ -1,0 +1,13 @@
+diff --git a/tools/gyp/pylib/gyp/generator/make.py b/tools/gyp/pylib/gyp/generator/make.py
+index f7f519b3e6..0fc5be2dd6 100644
+--- a/tools/gyp/pylib/gyp/generator/make.py
++++ b/tools/gyp/pylib/gyp/generator/make.py
+@@ -201,7 +201,7 @@ quiet_cmd_alink = LIBTOOL-STATIC $@
+ cmd_alink = rm -f $@ && ./gyp-mac-tool filter-libtool libtool $(GYP_LIBTOOLFLAGS) -static -o $@ $(filter %.o,$^)
+ 
+ quiet_cmd_link = LINK($(TOOLSET)) $@
+-cmd_link = $(LINK.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o "$@" $(LD_INPUTS) $(LIBS)
++cmd_link = $(CXX.$(TOOLSET)) $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o "$@" $(LD_INPUTS) $(LIBS)
+ 
+ quiet_cmd_solink = SOLINK($(TOOLSET)) $@
+ cmd_solink = $(LINK.$(TOOLSET)) -shared $(GYP_LDFLAGS) $(LDFLAGS.$(TOOLSET)) -o "$@" $(LD_INPUTS) $(LIBS)

--- a/node/patches/v8.x/012-changing-default-npm-settings.patch
+++ b/node/patches/v8.x/012-changing-default-npm-settings.patch
@@ -1,0 +1,22 @@
+diff --git a/deps/npm/lib/config/defaults.js b/deps/npm/lib/config/defaults.js
+index da019ac4d6..8b81e28940 100644
+--- a/deps/npm/lib/config/defaults.js
++++ b/deps/npm/lib/config/defaults.js
+@@ -166,7 +166,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
+     'legacy-bundling': false,
+     link: false,
+     'local-address': undefined,
+-    loglevel: 'notice',
++    loglevel: 'info',
+     logstream: process.stderr,
+     'logs-max': 10,
+     long: false,
+@@ -214,7 +214,7 @@ Object.defineProperty(exports, 'defaults', {get: function () {
+     'sign-git-tag': false,
+     'sso-poll-frequency': 500,
+     'sso-type': 'oauth',
+-    'strict-ssl': true,
++    'strict-ssl': false,
+     tag: 'latest',
+     'tag-version-prefix': 'v',
+     timing: false,


### PR DESCRIPTION
Pull request for the following patches :

* **010-execvp-arg-list-too-long.patch**

   needed to finalize HOST build on systems running gcc v6 series

* **011-gyp-force-link-command-to-use-CXX.patch**
    
     forcing CXX link with GYP

* **012-changing-default-npm-settings.patch**
   
   using **loglevel** to `info` and **strict-ssl** to `false` for NPM

