### PR TITLE
node-red-admin: add new package and npm-package.mk

### DIFF
--- a/node-red-admin/Makefile
+++ b/node-red-admin/Makefile
@@ -1,0 +1,48 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+include $(TOPDIR)/rules.mk
+
+PKG_NPM_NAME:=node-red-admin
+PKG_NAME:=$(PKG_NPM_NAME)
+PKG_VERSION:=0.1.5
+PKG_RELEASE:=1
+
+PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/
+PKG_HASH:=c65a2584bf2f68ddf9cb92538332e676c3366b2d2b1e7e9ec1f98b3a79d22a08
+
+PKG_MAINTAINER:=Jan Pavlinec <jan.pavlinec@nic.cz>
+PKG_LICENSE:=Apache-2.0
+PKG_LICENSE_FILES:=LICENSE
+
+PKG_BUILD_DEPENDS:=node/host
+PKG_BUILD_PARALLEL:=1
+PKG_USE_MIPS16:=0
+
+include $(INCLUDE_DIR)/package.mk
+include ../npm-package.mk
+
+define Package/node-red-admin
+  SUBMENU:=Node.js
+  SECTION:=lang
+  CATEGORY:=Languages
+  TITLE:=Admin tool for node-red
+  URL:=https://nodered.org/docs/user-guide/node-red-admin
+  DEPENDS:=+node +node-npm
+endef
+
+define Package/node-red-admin/description
+  The command-line tool allows you to remotely administer a Node-RED instance.
+endef
+
+TARGET_CFLAGS+=$(FPIC)
+TARGET_CPPFLAGS+=$(FPIC)
+
+define Package/node-red-admin/install
+	$(INSTALL_DIR) $(1)/usr/lib/node
+	$(CP) $(PKG_INSTALL_DIR)/usr/lib/node_modules/* $(1)/usr/lib/node/
+	$(INSTALL_DIR) $(1)/usr/bin
+	$(LN) ../lib/node/node-red-admin/node-red-admin.js $(1)/usr/bin/node-red-admin
+endef
+$(eval $(call BuildPackage,node-red-admin))

--- a/npm-package.mk
+++ b/npm-package.mk
@@ -1,0 +1,31 @@
+# This is free software, licensed under the GNU General Public License v2.
+# See /LICENSE for more information.
+#
+
+
+NODEJS_CPU ?=$(subst powerpc,ppc,$(subst aarch64,arm64,$(subst x86_64,x64,$(subst i386,ia32,$(ARCH)))))
+TMPNPM ?=$(shell mktemp -u XXXXXXXXXX)
+PKG_SOURCE ?=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
+
+define Build/Prepare/Node
+	$(INSTALL_DIR) $(PKG_BUILD_DIR)
+endef
+
+define Build/Compile/Node
+	$(MAKE_VARS) \
+	$(MAKE_FLAGS) \
+	npm_config_arch=$(NODEJS_CPU) \
+	npm_config_target_arch=$(NODEJS_CPU) \
+	npm_config_build_from_source=true \
+	npm_config_nodedir=$(STAGING_DIR)/usr/ \
+	npm_config_prefix=$(PKG_INSTALL_DIR)/usr/ \
+	npm_config_cache=$(TMP_DIR)/npm-cache-$(TMPNPM) \
+	npm_config_tmp=$(TMP_DIR)/npm-tmp-$(TMPNPM) \
+	npm install -g $(DL_DIR)/$(PKG_SOURCE)
+	rm -rf $(TMP_DIR)/npm-tmp-$(TMPNPM)
+	rm -rf $(TMP_DIR)/npm-cache-$(TMPNPM)
+endef
+
+
+Build/Prepare=$(call Build/Prepare/Node)
+Build/Compile=$(call Build/Compile/Node)


### PR DESCRIPTION
Maintainer: me
Compile tested: Turris Omnia (TOS5), OpenWrt master
Run tested: Turris Omnia (TS5), OpenWrt master

Description:
This PR adds new package node-red-admin which is CLI tool for node-red administration.
It also contains **npm-package.mk** which could simplify the packaging of npm packages  in the future .

