### PR TITLE
treewide: change dependency from libudev-fbsd to libudev

### DIFF
--- a/node-bleacon/Makefile
+++ b/node-bleacon/Makefile
@@ -29,7 +29,7 @@ define Package/node-bleacon
   CATEGORY:=Languages
   TITLE:=Library for creating/discovering/configuring iBeacons
   URL:=https://www.npmjs.org/package/bleacon
-  DEPENDS:=+node +node-bignum +bluez-libs +libudev-fbsd
+  DEPENDS:=+node +node-bignum +bluez-libs +libudev
 endef
 
 define Package/node-bleacon/description

--- a/node-bluetooth-hci-socket/Makefile
+++ b/node-bluetooth-hci-socket/Makefile
@@ -36,7 +36,7 @@ define Package/node-bluetooth-hci-socket
   CATEGORY:=Languages
   TITLE:=Bluetooth HCI socket binding for Node.js
   URL:=https://www.npmjs.com/package/bluetooth-hci-socket
-  DEPENDS:=+node +bluez-libs +libudev-fbsd +node-usb
+  DEPENDS:=+node +bluez-libs +libudev +node-usb
 endef
 
 define Package/node-bluetooth-hci-socket/description

--- a/node-eddystone-beacon/Makefile
+++ b/node-eddystone-beacon/Makefile
@@ -29,7 +29,7 @@ define Package/node-eddystone-beacon
   CATEGORY:=Languages
   TITLE:=Create an Eddystone Beacon using Node.js
   URL:=https://www.npmjs.org/package/eddystone-beacon
-  DEPENDS:=+node +bluez-libs +libudev-fbsd
+  DEPENDS:=+node +bluez-libs +libudev
 endef
 
 define Package/node-eddystone-beacon/description

--- a/node-hid/Makefile
+++ b/node-hid/Makefile
@@ -33,7 +33,7 @@ define Package/node-hid
   CATEGORY:=Languages
   TITLE:=Access USB HID devices from node.js
   URL:=https://www.npmjs.com/package/node-hid
-  DEPENDS:=+node +hidapi +libusb-1.0 +libudev-fbsd $(ICONV_DEPENDS)
+  DEPENDS:=+node +hidapi +libusb-1.0 +libudev $(ICONV_DEPENDS)
 endef
 
 define Package/node-hid/description

--- a/node-usb/Makefile
+++ b/node-usb/Makefile
@@ -29,7 +29,7 @@ define Package/node-usb
   CATEGORY:=Languages
   TITLE:=Library to access USB devices
   URL:=https://www.npmjs.com/package/usb
-  DEPENDS:=+node +libudev-fbsd
+  DEPENDS:=+node +libudev
 endef
 
 define Package/node-usb/description


### PR DESCRIPTION
Recently in OpenWrt packages repository, there was removed package
libudev-fbsd in favor of libudev-zero which provides libudev.

Cross-reference: https://github.com/openwrt/packages/pull/13720

It was not compile neither run tested.