### PR TITLE
reduce the size of the collected package and the number of files.

### DIFF
--- a/node-zigbee2mqtt/Makefile
+++ b/node-zigbee2mqtt/Makefile
@@ -55,7 +55,15 @@ define Build/Compile
 	npm_config_prefix=$(PKG_INSTALL_DIR)/usr/ \
 	npm_config_cache=$(TMP_DIR)/npm-cache-$(TMPNPM) \
 	npm_config_tmp=$(TMP_DIR)/npm-tmp-$(TMPNPM) \
-	npm install -g $(PKG_BUILD_DIR)
+	npm install -g --production $(PKG_BUILD_DIR)
+	rm $(PKG_BUILD_DIR)/node_modules/zigbee-herdsman/npm-shrinkwrap.json
+	rm $(PKG_BUILD_DIR)/node_modules/zigbee-herdsman-converters/npm-shrinkwrap.json
+	rm -f $(PKG_BUILD_DIR)/node_modules/zigbee2mqtt-frontend/dist/report.html
+	rm -f $(PKG_BUILD_DIR)/node_modules/zigbee2mqtt-frontend/dist/*.map
+	rm -f $(PKG_BUILD_DIR)/node_modules/zigbee2mqtt-frontend/dist/*/*.map
+	rm -rf $(PKG_BUILD_DIR)/node_modules/moment/min
+	rm -rf $(PKG_BUILD_DIR)/node_modules/moment/src
+	rm -rf $(PKG_BUILD_DIR)/node_modules/moment/locale
 	rm -rf $(TMP_DIR)/npm-tmp-$(TMPNPM)
 	rm -rf $(TMP_DIR)/npm-cache-$(TMPNPM)
 endef


### PR DESCRIPTION
on devices with openwrt, there is often little memory and it is important to use it usefully.

Deletes large files that are not used for zigbee2mqtt operation

Perhaps this is not the best solution, I will be glad to your advice