### PR TITLE
node-zigbee2mqtt: Changed the handling of configuration.yaml

### DIFF
--- a/node-zigbee2mqtt/Makefile
+++ b/node-zigbee2mqtt/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=zigbee2mqtt
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=1.22.1
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/
@@ -37,7 +37,8 @@ define Package/node-zigbee2mqtt/description
 endef
 
 define Package/node-zigbee2mqtt/conffiles
-/opt/zigbee2mqtt/data/configuration.yaml
+/etc/zigbee2mqtt/configuration.yaml
+/etc/zigbee2mqtt/
 endef
 
 TAR_OPTIONS+= --strip-components 1
@@ -86,6 +87,8 @@ define Package/node-zigbee2mqtt/install
 		$(1)/opt/$(PKG_NPM_NAME)/
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/zigbee2mqtt.init $(1)/etc/init.d/zigbee2mqtt
+	$(INSTALL_DIR) $(1)/etc/zigbee2mqtt
+	$(INSTALL_CONF) ./files/configuration.yaml $(1)/etc/zigbee2mqtt/configuration.yaml
 	$(INSTALL_DIR) $(1)/usr/lib/node_modules
 	$(LN) /opt/zigbee2mqtt $(1)/usr/lib/node_modules/zigbee2mqtt
 endef

--- a/node-zigbee2mqtt/files/configuration.yaml
+++ b/node-zigbee2mqtt/files/configuration.yaml
@@ -1,0 +1,35 @@
+# Home Assistant integration (MQTT discovery)
+homeassistant: false
+
+# allow new devices to join
+permit_join: true
+
+# MQTT settings
+mqtt:
+  # MQTT base topic for zigbee2mqtt MQTT messages
+  base_topic: zigbee2mqtt
+  # MQTT server URL
+  server: 'mqtt://localhost'
+  # MQTT server authentication, uncomment if required:
+  # user: my_user
+  # password: my_password
+
+# Serial settings
+serial:
+  # Location of CC2531 USB sniffer
+  port: /dev/ttyACM0
+
+advanced:
+  #baudrate: 1000000
+  log_level: info
+  # Optional: Location of log directory (default: shown below)
+  log_directory: /tmp/log/zigbee2mqtt/%TIMESTAMP%
+  # Optional: Log file name, can also contain timestamp, e.g.: zigbee2mqtt_%TIMESTAMP%.log (default: shown below)
+  log_file: log.txt
+  # Optional: Log rotation (default: shown below)
+  log_rotation: true
+  # Optional: Output location of the log (default: shown below), leave empty to supress logging (log_output: [])
+  # possible options: 'console', 'file', 'syslog'
+  log_output:
+   # - console
+    - file

--- a/node-zigbee2mqtt/files/configuration.yaml
+++ b/node-zigbee2mqtt/files/configuration.yaml
@@ -31,5 +31,5 @@ advanced:
   # Optional: Output location of the log (default: shown below), leave empty to supress logging (log_output: [])
   # possible options: 'console', 'file', 'syslog'
   log_output:
-   # - console
+    - console
     - file

--- a/node-zigbee2mqtt/files/zigbee2mqtt.init
+++ b/node-zigbee2mqtt/files/zigbee2mqtt.init
@@ -6,6 +6,7 @@ USE_PROCD=1
 start_service()
 {
 	procd_open_instance
+	procd_set_param env ZIGBEE2MQTT_DATA=/etc/zigbee2mqtt/
 	procd_set_param env NODE_PATH=/opt/zigbee2mqtt/node_modules/winston/node_modules:/opt/zigbee2mqtt/node_modules/zigbee-herdsman/node_modules
 	procd_set_param command /usr/bin/npm start --prefix /opt/zigbee2mqtt
 	procd_set_param stdout 1

--- a/node-zigbee2mqtt/files/zigbee2mqtt.init
+++ b/node-zigbee2mqtt/files/zigbee2mqtt.init
@@ -6,8 +6,7 @@ USE_PROCD=1
 start_service()
 {
 	procd_open_instance
-	procd_set_param env ZIGBEE2MQTT_DATA=/etc/zigbee2mqtt/
-	procd_set_param env NODE_PATH=/opt/zigbee2mqtt/node_modules/winston/node_modules:/opt/zigbee2mqtt/node_modules/zigbee-herdsman/node_modules
+	procd_set_param env ZIGBEE2MQTT_DATA=/etc/zigbee2mqtt/ NODE_PATH=/opt/zigbee2mqtt/node_modules/winston/node_modules:/opt/zigbee2mqtt/node_modules/zigbee-herdsman/node_modules
 	procd_set_param command /usr/bin/npm start --prefix /opt/zigbee2mqtt
 	procd_set_param stdout 1
 	procd_set_param stderr 1


### PR DESCRIPTION
Notable change:
* Changed location location of configuration.yaml from /opt/zigbee2mqtt/data/ to /etc/zigbee2mqtt.
      If you reinstall node-zigbee2mqtt, it will keep configuration.yaml.

* Changed location of log from /opt/zigbee2mqtt/data/log to /tmp/log/zigbee2mqtt.
