### PR TITLE
node-red: bump to 2.2.2

### DIFF
--- a/node-red/Makefile
+++ b/node-red/Makefile
@@ -6,12 +6,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NPM_NAME:=node-red
 PKG_NAME:=$(PKG_NPM_NAME)
-PKG_VERSION:=2.2.1
+PKG_VERSION:=2.2.2
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/
-PKG_HASH:=9780fa36d43263fbce4b9ac66feafdff08422476311c44dbf2f1ef8d8d165a19
+PKG_HASH:=d3b5c6a081b05fd92c32a1de19bf3a7d5c40c3b701ce1e35f7bcc960e1d367e9
 
 PKG_MAINTAINER:=Hirokazu MORIKAWA <morikw2@gmail.com>
 PKG_LICENSE:=Apache-2.0


### PR DESCRIPTION
(cherry picked from commit 79417443c44a121982187b222d27af722bc6d735)