### PR TITLE
node-sqlite3: fix incorrect package description

### DIFF
--- a/node-sqlite3/Makefile
+++ b/node-sqlite3/Makefile
@@ -36,7 +36,7 @@ define Package/node-sqlite3
 endef
 
 define Package/node-sqlite3/description
- Node.js package to access serial ports for reading and writing OR Welcome your robotic JavaScript overlords. Better yet, program them!
+ Asynchronous, non-blocking SQLite3 bindings for Node.js
 endef
 
 TAR_OPTIONS+= --strip-components 1


### PR DESCRIPTION
Updates the description for node-sqlite3 using the description copied from [node-sqlite3's Git repo](https://github.com/TryGhost/node-sqlite3)

The previous description for node-sqlite3 was actually from [node-serialport](https://github.com/serialport/node-serialport).