### PR TITLE
node: drop depends from config to allow change versions on host

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -83,7 +83,6 @@ endef
 
 define Package/node/config
 	menu "Configuration"
-		depends on PACKAGE_node
 
 	choice
 		prompt "Version Selection"


### PR DESCRIPTION
Description:

This change ensures that on unsupported targets like mpc85xx, you can
choose host node version by using either ``make menuconfig`` or manually enable
CONFIG_NODEJS_version(14/16/18). 

Before this change:
- I tried to use CONFIG_NODEJS_14 or CONFIG_NODEJS_16 for mvebu, where
  it works, but mpc85xx could not recognize it and fails with:
``ERROR: Config option is not present in generated config: CONFIG_NODEJS_16=y``
   - It was not possible to choose host version for node.

- So, always, on the unsupported target/router, where node is not
  available, it was using the latest node
  version, which is for all OpenWrt versions (currently) - 18.
It seems like some software is not ready for it, and it is a good idea
to expose version changes even for host.
  - Related: https://gitlab.nic.cz/turris/reforis/reforis/-/issues/393

_____

Screenshots:

Before this change on router, where node is unsupported:
![image](https://user-images.githubusercontent.com/4096468/196060363-9fe480a2-7969-4ba6-bd0a-eb89f7e5c17c.png)


After this change on router, where node is unsupported:
![image](https://user-images.githubusercontent.com/4096468/196060332-4908fbab-9394-4033-b403-44682275f40d.png)

Would be nice to have this backported to all OpenWrt branches.

____

Steps to reproduce:
1. Download OpenWrt build system for router, where node is not available
2. Compile host package ``make package/node/host/compile``