### PR TITLE
[22.03] node-bluetooth-hci-socket: add depend bluez-libs

### DIFF
--- a/node-bluetooth-hci-socket/Makefile
+++ b/node-bluetooth-hci-socket/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=bluetooth-hci-socket
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=0.5.3
-PKG_RELEASE:=4
+PKG_RELEASE:=5
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/noble/node-bluetooth-hci-socket.git
@@ -36,7 +36,7 @@ define Package/node-bluetooth-hci-socket
   CATEGORY:=Languages
   TITLE:=Bluetooth HCI socket binding for Node.js
   URL:=https://www.npmjs.com/package/bluetooth-hci-socket
-  DEPENDS:=+node +node-usb
+  DEPENDS:=+node +node-usb +bluez-libs
 endef
 
 define Package/node-bluetooth-hci-socket/description


### PR DESCRIPTION
(cherry picked from commit 8cb170b78cada5b279cd90d9a99a6afdc52c674a)