### PR TITLE
[22.03] node-zeromq: 0MQ version 4.3.5 stable

### DIFF
--- a/node-zeromq/Makefile
+++ b/node-zeromq/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=zeromq
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=6.0.0-beta.17
-PKG_RELEASE:=3
+PKG_RELEASE:=4
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/

--- a/node-zeromq/patches/001-modify_compile_options.patch
+++ b/node-zeromq/patches/001-modify_compile_options.patch
@@ -5,7 +5,7 @@
      const zmq_rev = 
      // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing, @typescript-eslint/strict-boolean-expressions
 -    process.env.ZMQ_VERSION || "20de92ac0a2b2b9a1869782a429df68f93c3625e";
-+    process.env.ZMQ_VERSION || "de5ee18203f4ba472812fd08665603cd3f88955d";
++    process.env.ZMQ_VERSION || "622fc6dde99ee172ebaa9c8628d85a7a1995a21d";
      const src_url = `https://github.com/zeromq/libzmq/archive/${zmq_rev}.tar.gz`;
      const libzmq_build_prefix = `${root}/build/libzmq-staging`;
      const libzmq_install_prefix = `${root}/build/libzmq`;


### PR DESCRIPTION
(cherry picked from commit 8d5602d6365c60c45991d073e50c784924bcf407)