### PR TITLE
[22.03] node-homebridge-config-ui-x: fix getPidOfPort

### DIFF
--- a/node-homebridge-config-ui-x/files/openwrt.js
+++ b/node-homebridge-config-ui-x/files/openwrt.js
@@ -92,12 +92,7 @@ class LinuxInstaller extends base_platform_1.BasePlatform {
     }
     getPidOfPort(port) {
         try {
-            if (this.hbService.docker) {
-                return child_process.execSync('pidof homebridge').toString('utf8').trim();
-            }
-            else {
-                return child_process.execSync(`fuser ${port}/tcp 2>/dev/null`).toString('utf8').trim();
-            }
+            return child_process.execSync('pidof homebridge').toString('utf8').trim();
         }
         catch (e) {
             return null;


### PR DESCRIPTION
(cherry picked from commit 3447626861112d6980e531434c44e2a01c51d2d9)