### PR TITLE
[24.10] node: support riscv64 Banana Pi BPI-RV2 RISC-V

### DIFF
--- a/node/Makefile
+++ b/node/Makefile
@@ -67,7 +67,7 @@ define Package/node
   SUBMENU:=Node.js
   TITLE:=Node.js is a platform built on Chrome's JavaScript runtime
   URL:=https://nodejs.org/
-  DEPENDS:=@HAS_FPU @(i386||x86_64||arm||aarch64) \
+  DEPENDS:=@HAS_FPU @(i386||x86_64||arm||aarch64||riscv64) \
 	   +libstdcpp +libopenssl +zlib +libnghttp2 \
 	   +libcares +libatomic +NODEJS_ICU_SYSTEM:icu +NODEJS_ICU_SYSTEM:icu-full-data
   ABI_VERSION:=$(NODE_MODULE_VERSION)


### PR DESCRIPTION
(cherry picked from commit d928bfa5e621184f5bbf44e19b675c69ef49dac7)