### PR TITLE
[23.05] node-leveldown: @!riscv64

### DIFF
--- a/node-leveldown/Makefile
+++ b/node-leveldown/Makefile
@@ -29,7 +29,7 @@ define Package/node-leveldown
   CATEGORY:=Languages
   TITLE:=A Node.js LevelDB binding, primary backend for LevelUP
   URL:=https://www.npmjs.org/package/leveldown
-  DEPENDS:=+node
+  DEPENDS:=+node @!riscv64
 endef
 
 define Package/node-leveldown/description


### PR DESCRIPTION
(cherry picked from commit a6bad0f65254816c90360279c0656b8fd09c710f)