### PR TITLE
[24.10] node-classic-level: support riscv64

### DIFF
--- a/node-classic-level/Makefile
+++ b/node-classic-level/Makefile
@@ -7,7 +7,7 @@ include $(TOPDIR)/rules.mk
 PKG_NPM_NAME:=classic-level
 PKG_NAME:=node-$(PKG_NPM_NAME)
 PKG_VERSION:=2.0.0
-PKG_RELEASE:=2
+PKG_RELEASE:=3
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/
@@ -29,7 +29,7 @@ define Package/node-classic-level
   CATEGORY:=Languages
   TITLE:=An abstract-level database backed by LevelDB
   URL:=https://www.npmjs.org/package/classic-level
-  DEPENDS:=+node @!riscv64
+  DEPENDS:=+node
 endef
 
 define Package/node-classic-level/description

--- a/node-classic-level/patches/999-support_riscv64.patch
+++ b/node-classic-level/patches/999-support_riscv64.patch
@@ -1,0 +1,25 @@
+--- a/deps/leveldb/leveldb-1.20/port/atomic_pointer.h
++++ b/deps/leveldb/leveldb-1.20/port/atomic_pointer.h
+@@ -41,6 +41,8 @@
+ #define ARCH_CPU_PPC_FAMILY 1
+ #elif defined(__mips__)
+ #define ARCH_CPU_MIPS_FAMILY 1
++#elif defined(__riscv)
++#define ARCH_CPU_RISCV64_FAMILY 1
+ #endif
+ 
+ namespace leveldb {
+@@ -103,6 +105,13 @@ inline void MemoryBarrier() {
+ }
+ #define LEVELDB_HAVE_MEMORY_BARRIER
+ 
++// RISCV64
++#elif defined(ARCH_CPU_RISCV64_FAMILY)
++inline void MemoryBarrier() {
++  asm volatile("fence iorw, iorw" : : : "memory");
++}
++#define LEVELDB_HAVE_MEMORY_BARRIER
++
+ // PPC
+ #elif defined(ARCH_CPU_PPC_FAMILY) && defined(__GNUC__)
+ inline void MemoryBarrier() {


### PR DESCRIPTION
(cherry picked from commit 870aef26f55d7e543d7a8c144ff465a66486cc24)