### PR TITLE
[24.10] node-homebridge-config-ui-x: bump to 5.4.1

### DIFF
--- a/node-homebridge-config-ui-x/Makefile
+++ b/node-homebridge-config-ui-x/Makefile
@@ -6,12 +6,12 @@ include $(TOPDIR)/rules.mk
 
 PKG_NPM_NAME:=homebridge-config-ui-x
 PKG_NAME:=node-$(PKG_NPM_NAME)
-PKG_VERSION:=5.4.0
+PKG_VERSION:=5.4.1
 PKG_RELEASE:=1
 
 PKG_SOURCE:=$(PKG_NPM_NAME)-$(PKG_VERSION).tgz
 PKG_SOURCE_URL:=https://registry.npmjs.org/$(PKG_NPM_NAME)/-/
-PKG_HASH:=e845106c58f78fdbc3487f0caf92db5abb1b139eee74eb5842e3c84fa23de0e6
+PKG_HASH:=2af0bc58a3b8bab8149656c82af4d29d05cea3680c186135a0bfd9cae49553ac
 
 PKG_BUILD_DEPENDS:=node/host node-clean-modules/host
 PKG_BUILD_FLAGS:=no-mips16


### PR DESCRIPTION
(cherry picked from commit bd70884cfb7f6eb3c7723521eb9cf89ffe943520)