### PR TITLE
[24.10] node: v24.x backport patch for riscv build error

### DIFF
--- a/node/patches/v24.x/999-backport_for_riscv.patch
+++ b/node/patches/v24.x/999-backport_for_riscv.patch
@@ -1,0 +1,67 @@
+--- a/deps/v8/src/codegen/riscv/assembler-riscv-inl.h	2025-10-09 04:56:39.000000000 +0900
++++ b/deps/v8/src/codegen/riscv/assembler-riscv-inl.h	2025-10-16 15:19:49.779272293 +0900
+@@ -115,8 +115,9 @@ void Assembler::set_target_compressed_ad
+     Address pc, Address constant_pool, Tagged_t target,
+     WritableJitAllocation* jit_allocation, ICacheFlushMode icache_flush_mode) {
+   if (COMPRESS_POINTERS_BOOL) {
+-    Assembler::set_uint32_constant_at(pc, constant_pool, target, jit_allocation,
+-                                      icache_flush_mode);
++    Assembler::set_uint32_constant_at(pc, constant_pool,
++                                      static_cast<uint32_t>(target),
++                                      jit_allocation, icache_flush_mode);
+   } else {
+     UNREACHABLE();
+   }
+--- a/deps/v8/src/execution/riscv/simulator-riscv.h	2025-10-09 04:56:39.000000000 +0900
++++ b/deps/v8/src/execution/riscv/simulator-riscv.h	2025-10-16 15:19:49.779272293 +0900
+@@ -538,6 +538,7 @@ class Simulator : public SimulatorBase {
+   // Return central stack view, without additional safety margins.
+   // Users, for example wasm::StackMemory, can add their own.
+   base::Vector<uint8_t> GetCentralStackView() const;
++  static constexpr int JSStackLimitMargin() { return kAdditionalStackMargin; }
+ 
+   void IterateRegistersAndStack(::heap::base::StackVisitor* visitor);
+ 
+--- a/deps/v8/src/maglev/riscv/maglev-ir-riscv.cc	2025-10-09 04:56:39.000000000 +0900
++++ b/deps/v8/src/maglev/riscv/maglev-ir-riscv.cc	2025-10-16 15:19:49.779272293 +0900
+@@ -224,6 +224,40 @@ void CheckedIntPtrToInt32::GenerateCode(
+                             Operand(std::numeric_limits<int32_t>::min()));
+ }
+ 
++void CheckFloat64SameValue::SetValueLocationConstraints() {
++  UseRegister(target_input());
++  // We need two because LoadFPRImmediate needs to acquire one as well in the
++  // case where value() is not 0.0 or -0.0.
++  set_temporaries_needed((value().get_scalar() == 0) ? 1 : 2);
++  set_double_temporaries_needed(
++      value().is_nan() || (value().get_scalar() == 0) ? 0 : 1);
++}
++
++void CheckFloat64SameValue::GenerateCode(MaglevAssembler* masm,
++                                         const ProcessingState& state) {
++  Label* fail = __ GetDeoptLabel(this, deoptimize_reason());
++  MaglevAssembler::TemporaryRegisterScope temps(masm);
++  DoubleRegister target = ToDoubleRegister(target_input());
++  if (value().is_nan()) {
++    __ JumpIfNotNan(target, fail);
++  } else {
++    DoubleRegister double_scratch = temps.AcquireScratchDouble();
++    Register scratch = temps.AcquireScratch();
++    __ Move(double_scratch, value().get_scalar());
++    __ CompareF64(scratch, EQ, double_scratch, target);
++    __ BranchFalseF(scratch, fail);
++    if (value().get_scalar() == 0) {  // +0.0 or -0.0.
++      __ MacroAssembler::Move(scratch, target);
++      __ And(scratch, scratch, Operand(1ULL << 63));
++      if (value().get_bits() == 0) {
++        __ BranchTrueF(scratch, fail);
++      } else {
++        __ BranchFalseF(scratch, fail);
++      }
++    }
++  }
++}
++
+ void Int32AddWithOverflow::SetValueLocationConstraints() {
+   UseRegister(left_input());
+   UseRegister(right_input());


### PR DESCRIPTION
(cherry picked from commit d7a0a60499e09d28b03337afa6d4d0c1345926bf)