### PR TITLE
[24.10] treewide: address axios CVE-2026-40175

### DIFF
--- a/node-aws-crt/patches/999-fix_axios_error.patch
+++ b/node-aws-crt/patches/999-fix_axios_error.patch
@@ -5,7 +5,7 @@
    },
    "overrides": {
 -    "axios": "^1.12.2"
-+    "axios": "1.14.0"
++    "axios": "1.15.0"
    },
    "devDependencies": {
      "@types/crypto-js": "^3.1.43",
@@ -14,7 +14,7 @@
      "@aws-sdk/util-utf8-browser": "^3.259.0",
      "@httptoolkit/websocket-stream": "^6.0.1",
 -    "axios": "^1.12.2",
-+    "axios": "1.14.0",
++    "axios": "1.15.0",
      "buffer": "^6.0.3",
      "crypto-js": "^4.2.0",
      "mqtt": "^4.3.8",

--- a/node-camera.ui/patches/000-remove_depends.patch
+++ b/node-camera.ui/patches/000-remove_depends.patch
@@ -10,7 +10,7 @@
 -    "alexa-remote2": "^4.1.2",
 -    "axios": "^0.26.1",
 +    "alexa-remote2": "^7.0.4",
-+    "axios": "^1.6.8",
++    "axios": "^1.15.0",
      "bunyan": "^1.8.15",
 -    "chalk": "4.1.2",
 -    "check-disk-space": "^3.3.0",


### PR DESCRIPTION
(cherry picked from commit cd7a18ef7d1f9cb5480f8b579a83593f16ce4a0c)