### PR TITLE
node-zigbee2mqtt: wait for serial + network at boot, unlimited respawn

### DIFF
--- a/node-zigbee2mqtt/files/zigbee2mqtt.init
+++ b/node-zigbee2mqtt/files/zigbee2mqtt.init
@@ -3,12 +3,43 @@
 START=99
 USE_PROCD=1
 
-start_service()
-{
+. /lib/functions/network.sh
+
+CONFIG_FILE="${ZIGBEE2MQTT_DATA:-/etc/zigbee2mqtt}/configuration.yaml"
+
+start_service() {
+	# Wait for the serial adapter (if any) referenced in configuration.yaml.
+	# USB enumeration of cp210x/CH341 can lag procd init by several seconds.
+	# Skipped when port is not a device path (network coordinator over TCP)
+	# or when no config is present yet (first-run scenarios).
+	if [ -r "$CONFIG_FILE" ]; then
+		local port
+		port=$(awk '/^[[:space:]]*port:[[:space:]]*\// {print $2; exit}' "$CONFIG_FILE")
+		if [ -n "$port" ]; then
+			local i=0
+			while [ ! -e "$port" ] && [ $i -lt 60 ]; do
+				sleep 1
+				i=$((i + 1))
+			done
+		fi
+	fi
+
+	# Wait for the network to come up (event-driven via netifd). Best-effort:
+	# falls through after the timeout so headless / LAN-only setups still start.
+	local iface
+	network_find_wan iface || network_find_wan6 iface || iface="wan"
+	local n=0
+	while [ $n -lt 60 ] && ! network_is_up "$iface"; do
+		sleep 2
+		n=$((n + 2))
+	done
+
 	procd_open_instance
 	procd_set_param env HOME=/root ZIGBEE2MQTT_DATA=/etc/zigbee2mqtt/ NODE_OPTIONS=--insecure-http-parser NODE_PATH=/opt/zigbee2mqtt/node_modules/winston/node_modules:/opt/zigbee2mqtt/node_modules/zigbee-herdsman/node_modules
 	procd_set_param command /usr/bin/node --optimize_for_size --max_old_space_size=128 --gc_interval=100 /opt/zigbee2mqtt/index.js
-	procd_set_param respawn
+	# Unlimited respawn: don't give up after the default 5 crashes in 5 min.
+	# Handles slow-to-settle dependencies (serial adapter, remote broker).
+	procd_set_param respawn 3600 10 0
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_set_param term_timeout 60


### PR DESCRIPTION
## Summary

The shipped procd init for `node-zigbee2mqtt` has no startup dependencies and uses the default respawn limit (5 crashes / 5 minutes). On real hardware this leads to a class of post-reboot failures where zigbee2mqtt does not come up automatically, but a manual `/etc/init.d/zigbee2mqtt start` succeeds.

Two slow-to-settle dependencies are the typical cause:

- **USB enumeration of the Zigbee adapter** (cp210x / CH341 / CDC-ACM): on slower boards the controller device (e.g. `/dev/ttyUSB0`) appears a few seconds after procd has already started services with `START=99`. `zigbee-herdsman` fails to open the port and node exits.
- **Remote MQTT broker** over a slow-to-up link (PPPoE, WireGuard, BGP, etc.): the initial connect fails with `ECONNREFUSED` / `ENETUNREACH` and node exits.

In both cases the rapid crash loop trips the default respawn limit within seconds, procd gives up, and the service stays down until a human intervenes.

## Change

Three small, backward-compatible safeguards in `start_service`:

1. **Wait up to 60 s for the serial port** parsed from `configuration.yaml`. Skipped when `port` is not a device path (TCP coordinator) or when the config file does not yet exist (first-run installs).
2. **Wait up to 60 s for the network** using netifd's `network_is_up` from `/lib/functions/network.sh` (event-driven; returns immediately once the interface is configured). Best-effort — falls through on timeout so headless / LAN-only setups still start.
3. **Unlimited respawn** (`procd_set_param respawn 3600 10 0`) so procd keeps retrying when a dependency takes longer than expected to come up.

No new package dependencies; `network.sh` is part of `base-files`.

## Compatibility

- Existing installs see no behavioural regression: serial wait is opt-in via the parsed config, network wait falls through, respawn change is strictly safer.
- TCP-only coordinators are unaffected (no device-path port in config → no wait).
- Boxes without WAN configuration fall through the network wait after 60 s and start normally.

## Test

Deployed on a Turris Omnia (TurrisOS 9.1.0, `node-zigbee2mqtt 2.10.1-r1`) where post-reboot startup failures were reproducible. After the change the service starts reliably on every reboot; manual `/etc/init.d/zigbee2mqtt restart` continues to work as before.
