### PR TITLE
[25.12] node-zigbee2mqtt: wait for serial + network at boot, unlimited respawn

### DIFF
--- a/node-zigbee2mqtt/files/zigbee2mqtt.init
+++ b/node-zigbee2mqtt/files/zigbee2mqtt.init
@@ -3,12 +3,43 @@
 START=99
 USE_PROCD=1
 
-start_service()
-{
+. /lib/functions/network.sh
+
+CONFIG_FILE="${ZIGBEE2MQTT_DATA:-/etc/zigbee2mqtt}/configuration.yaml"
+
+start_service() {
+	# Wait for the serial adapter (if any) referenced in configuration.yaml.
+	# USB enumeration of cp210x/CH341 can lag procd init by several seconds.
+	# Skipped when port is not a device path (network coordinator over TCP)
+	# or when no config is present yet (first-run scenarios).
+	if [ -r "$CONFIG_FILE" ]; then
+		local port
+		port=$(awk '/^[[:space:]]*port:[[:space:]]*\// {print $2; exit}' "$CONFIG_FILE")
+		if [ -n "$port" ]; then
+			local i=0
+			while [ ! -e "$port" ] && [ $i -lt 60 ]; do
+				sleep 1
+				i=$((i + 1))
+			done
+		fi
+	fi
+
+	# Wait for the network to come up (event-driven via netifd). Best-effort:
+	# falls through after the timeout so headless / LAN-only setups still start.
+	local iface
+	network_find_wan iface || network_find_wan6 iface || iface="wan"
+	local n=0
+	while [ $n -lt 60 ] && ! network_is_up "$iface"; do
+		sleep 2
+		n=$((n + 2))
+	done
+
 	procd_open_instance
 	procd_set_param env HOME=/root ZIGBEE2MQTT_DATA=/etc/zigbee2mqtt/ NODE_OPTIONS=--insecure-http-parser NODE_PATH=/opt/zigbee2mqtt/node_modules/winston/node_modules:/opt/zigbee2mqtt/node_modules/zigbee-herdsman/node_modules
 	procd_set_param command /usr/bin/node --optimize_for_size --max_old_space_size=128 --gc_interval=100 /opt/zigbee2mqtt/index.js
-	procd_set_param respawn
+	# Unlimited respawn: don't give up after the default 5 crashes in 5 min.
+	# Handles slow-to-settle dependencies (serial adapter, remote broker).
+	procd_set_param respawn 3600 10 0
 	procd_set_param stdout 1
 	procd_set_param stderr 1
 	procd_set_param term_timeout 60


### PR DESCRIPTION
The shipped procd init has no startup dependencies and uses the default respawn limit (5 crashes / 5 min). On real boards this leads to a class of failures where zigbee2mqtt does not come up after reboot:

  - USB enumeration of the Zigbee adapter (cp210x / CH341 etc.) can lag procd init by several seconds; node opens the configured port, fails with ENOENT, exits.
  - The MQTT broker can live on a remote host reached via a slow-to-up link (PPPoE, BGP, WireGuard); early connect fails with ECONNREFUSED / ENETUNREACH and node exits.

In both cases the rapid crash loop trips the respawn limit within seconds and procd stops trying. A manual '/etc/init.d/zigbee2mqtt start' then succeeds.

This change adds three small, backward-compatible safeguards:

  - Wait up to 60 s for the serial port parsed from configuration.yaml. Skipped when 'port' is not a device path (TCP coordinator) or when the config file is not yet present (first-run installs).
  - Wait up to 60 s for the network to become available, using netifd's network_is_up helper from /lib/functions/network.sh (event-driven, returns immediately once the interface is configured). Best-effort: falls through on timeout so headless/LAN-only setups still start.
  - Use 'procd_set_param respawn 3600 10 0' (unlimited retry) so procd keeps trying when a dependency takes a bit longer to settle.

No new dependencies; network.sh ships with base-files. Existing installations see no behavioural regression — only an additional short wait when dependencies happen to not be ready yet at startup.

(cherry picked from commit 56e6ed520ce0be34b931addaaec4af2ddcd913f5)